### PR TITLE
Add UnifiedAccessPass support for template pair responses

### DIFF
--- a/AccessGridTest/AccessCardsServiceTests.cs
+++ b/AccessGridTest/AccessCardsServiceTests.cs
@@ -13,11 +13,11 @@ public class AccessCardsServiceTests
     {
         // Arrange
         var mockApiService = new Mock<IApiService>();
-        var expectedCard = new AccessCard("test-card-id", "Test User", "active", null);
+        var jsonResponse = @"{""id"":""test-card-id"",""full_name"":""Test User"",""state"":""active""}";
 
         mockApiService
-            .Setup(x => x.PostAsync<AccessCard>("/v1/key-cards", It.IsAny<ProvisionCardRequest>()))
-            .ReturnsAsync(expectedCard);
+            .Setup(x => x.PostAsync<string>("/v1/key-cards", It.IsAny<ProvisionCardRequest>()))
+            .ReturnsAsync(jsonResponse);
 
         var service = new AccessCardsService(mockApiService.Object);
         var request = new ProvisionCardRequest
@@ -31,8 +31,10 @@ public class AccessCardsServiceTests
         var result = await service.IssueAsync(request);
 
         // Assert
-        Assert.That(result.Id, Is.EqualTo(expectedCard.Id));
-        Assert.That(result.FullName, Is.EqualTo(expectedCard.FullName));
-        mockApiService.Verify(x => x.PostAsync<AccessCard>("/v1/key-cards", request), Times.Once);
+        Assert.That(result, Is.InstanceOf<AccessCard>());
+        var card = (AccessCard)result;
+        Assert.That(card.Id, Is.EqualTo("test-card-id"));
+        Assert.That(card.FullName, Is.EqualTo("Test User"));
+        mockApiService.Verify(x => x.PostAsync<string>("/v1/key-cards", request), Times.Once);
     }
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Official C# SDK for interacting with the AccessGrid API.
 ## Installation
 
 ```
-Install-Package accessgrid -Version 1.1.3
+Install-Package accessgrid -Version 1.1.4
 ```
 
 ## Authentication

--- a/example/Example.cs
+++ b/example/Example.cs
@@ -60,7 +60,10 @@ namespace AccessGridExample
                     ExpirationDate = DateTime.UtcNow.AddYears(1)
                 });
 
-                Console.WriteLine($"Card provisioned successfully. Install URL: {newCard.Url}");
+                if (newCard is AccessCard accessCard)
+                    Console.WriteLine($"Card provisioned successfully. Install URL: {accessCard.Url}");
+                else if (newCard is UnifiedAccessPass unifiedAccessPass)
+                    Console.WriteLine($"Unified pass provisioned successfully. Install URL: {unifiedAccessPass.Url}");
 
                 // // Example 3: Update a card
                 // Console.WriteLine("\nUpdating a card...");

--- a/src/AccessGrid.csproj
+++ b/src/AccessGrid.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <PackageId>accessgrid</PackageId>
-    <Version>1.1.3</Version>
+    <Version>1.1.4</Version>
     <Authors>AccessGrid</Authors>
     <Company>AccessGrid</Company>
     <Description>Official C# SDK for the AccessGrid API</Description>

--- a/src/AccessGrid/AccessCardsService.cs
+++ b/src/AccessGrid/AccessCardsService.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace AccessGrid
@@ -16,22 +17,27 @@ namespace AccessGrid
         }
 
         /// <summary>
-        /// Issues a new access card
+        /// Issues a new access card or unified access pass (for template pairs)
         /// </summary>
         /// <param name="request">Card provision details</param>
-        /// <returns>Newly created AccessCard</returns>
-        public async Task<AccessCard> IssueAsync(ProvisionCardRequest request)
+        /// <returns>AccessCard for single card, or UnifiedAccessPass for template pairs</returns>
+        public async Task<Union> IssueAsync(ProvisionCardRequest request)
         {
-            var response = await _apiService.PostAsync<AccessCard>("/v1/key-cards", request);
-            return response;
+            var json = await _apiService.PostAsync<string>("/v1/key-cards", request);
+            var card = JsonSerializer.Deserialize<AccessCard>(json);
+
+            if (card.Details != null)
+                return JsonSerializer.Deserialize<UnifiedAccessPass>(json);
+
+            return card;
         }
 
         /// <summary>
         /// Alias for IssueAsync to maintain backward compatibility
         /// </summary>
         /// <param name="request">Card provision details</param>
-        /// <returns>Newly created AccessCard</returns>
-        public async Task<AccessCard> ProvisionAsync(ProvisionCardRequest request)
+        /// <returns>AccessCard for single card, or UnifiedAccessPass for template pairs</returns>
+        public async Task<Union> ProvisionAsync(ProvisionCardRequest request)
         {
             return await IssueAsync(request);
         }

--- a/src/AccessGrid/Models.cs
+++ b/src/AccessGrid/Models.cs
@@ -4,6 +4,32 @@ using System.Text.Json.Serialization;
 
 namespace AccessGrid
 {
+    /// <summary>
+    /// Base type for card issue responses (AccessCard or UnifiedAccessPass)
+    /// </summary>
+    public abstract class Union { }
+
+    /// <summary>
+    /// Represents a unified access pass containing multiple cards (Apple + Android)
+    /// </summary>
+    public class UnifiedAccessPass : Union
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("install_url")]
+        public string Url { get; set; }
+
+        [JsonPropertyName("state")]
+        public string State { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("details")]
+        public List<AccessCard> Details { get; set; }
+    }
+
     public class Device
     {
         [JsonPropertyName("id")]
@@ -25,7 +51,7 @@ namespace AccessGrid
         public DateTime? UpdatedAt { get; set; }
     }
 
-    public class AccessCard
+    public class AccessCard : Union
     {
         [JsonConstructor]
         internal AccessCard(string id, string url, string state)


### PR DESCRIPTION
## Summary
- Add `Union` abstract base class for polymorphic card issue responses
- Add `UnifiedAccessPass` class to handle API responses with `details` array (Apple + Android cards)
- Update `IssueAsync()` to return `Union` and detect response type via `Details` property
- Bump version to 1.1.4

## Usage
```csharp
var result = await client.AccessCards.IssueAsync(request);

if (result is UnifiedAccessPass unifiedAccessPass)
    Console.WriteLine($"Got {unifiedAccessPass.Details.Count} cards");
else if (result is AccessCard accessCard)
    Console.WriteLine($"Got card {accessCard.Id}");
```