### PR TITLE
Flatten CreateTemplateRequest params to match API

### DIFF
--- a/AccessGridTest/AccessGridTest.csproj
+++ b/AccessGridTest/AccessGridTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/AccessGridTest/ConsoleServiceTests.cs
+++ b/AccessGridTest/ConsoleServiceTests.cs
@@ -165,7 +165,8 @@ public class ConsoleServiceTests
             "protocol": "desfire",
             "created_at": "2025-03-01T00:00:00Z",
             "issued_keys_count": 0,
-            "active_keys_count": 0
+            "active_keys_count": 0,
+            "metadata": { "version": "2.1" }
         }
         """;
         StubHttpResponse(json);
@@ -178,7 +179,20 @@ public class ConsoleServiceTests
             Protocol = Protocol.DESFire,
             AllowOnMultipleDevices = true,
             WatchCount = 2,
-            IPhoneCount = 3
+            IPhoneCount = 3,
+            BackgroundColor = "#FFFFFF",
+            LabelColor = "#000000",
+            LabelSecondaryColor = "#333333",
+            SupportUrl = "https://help.yourcompany.com",
+            SupportPhoneNumber = "+1-555-123-4567",
+            SupportEmail = "support@yourcompany.com",
+            PrivacyPolicyUrl = "https://yourcompany.com/privacy",
+            TermsAndConditionsUrl = "https://yourcompany.com/terms",
+            Metadata = new Dictionary<string, object>
+            {
+                ["version"] = "2.1",
+                ["approval_status"] = "approved"
+            }
         };
 
         var result = await _client.Console.CreateTemplateAsync(request);
@@ -194,6 +208,54 @@ public class ConsoleServiceTests
             req.Method == HttpMethod.Post &&
             req.RequestUri!.ToString().Contains("/v1/console/card-templates")
         )), Times.Once);
+    }
+
+    [Test]
+    public async Task CreateTemplateAsync_SendsFlatDesignAndSupportParams()
+    {
+        var json = """
+        {
+            "id": "tmpl-flat",
+            "name": "Flat Params Template",
+            "platform": "apple",
+            "use_case": "employee_badge",
+            "protocol": "desfire",
+            "metadata": { "version": "2.1" }
+        }
+        """;
+
+        string capturedBody = null;
+        _mockHttpClient
+            .Setup(x => x.SendAsync(It.IsAny<HttpRequestMessage>()))
+            .Returns<HttpRequestMessage>(async req =>
+            {
+                if (req.Content != null)
+                    capturedBody = await req.Content.ReadAsStringAsync();
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+        var request = new CreateTemplateRequest
+        {
+            Name = "Flat Params Template",
+            Platform = Platform.Apple,
+            UseCase = "employee_badge",
+            Protocol = Protocol.DESFire,
+            BackgroundColor = "#FFFFFF",
+            SupportUrl = "https://help.yourcompany.com",
+            Metadata = new Dictionary<string, object> { ["version"] = "2.1" }
+        };
+
+        await _client.Console.CreateTemplateAsync(request);
+
+        Assert.That(capturedBody, Is.Not.Null);
+        // Flat params should appear at root level, not nested under design/support_info
+        Assert.That(capturedBody, Does.Contain("background_color"));
+        Assert.That(capturedBody, Does.Contain("support_url"));
+        Assert.That(capturedBody, Does.Not.Contain("\"design\""));
+        Assert.That(capturedBody, Does.Not.Contain("\"support_info\""));
     }
 
     #endregion

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Official C# SDK for interacting with the AccessGrid API.
 ## Installation
 
 ```
-Install-Package accessgrid -Version 1.2.2
+Install-Package accessgrid -Version 1.3.0
 ```
 
 ## Authentication
@@ -232,29 +232,25 @@ public async Task CreateTemplateAsync()
 
    var template = await client.Console.CreateTemplateAsync(new CreateTemplateRequest
    {
-       Name = "Employee NFC key",
+       Name = "Employee Access Pass",
        Platform = "apple",
        UseCase = "employee_badge",
        Protocol = "desfire",
        AllowOnMultipleDevices = true,
        WatchCount = 2,
        IPhoneCount = 3,
-       Design = new TemplateDesign
+       BackgroundColor = "#FFFFFF",
+       LabelColor = "#000000",
+       LabelSecondaryColor = "#333333",
+       SupportUrl = "https://help.yourcompany.com",
+       SupportPhoneNumber = "+1-555-123-4567",
+       SupportEmail = "support@yourcompany.com",
+       PrivacyPolicyUrl = "https://yourcompany.com/privacy",
+       TermsAndConditionsUrl = "https://yourcompany.com/terms",
+       Metadata = new Dictionary<string, object>
        {
-           BackgroundColor = "#FFFFFF",
-           LabelColor = "#000000",
-           LabelSecondaryColor = "#333333",
-           BackgroundImage = "[image_in_base64_encoded_format]",
-           LogoImage = "[image_in_base64_encoded_format]",
-           IconImage = "[image_in_base64_encoded_format]"
-       },
-       SupportInfo = new SupportInfo
-       {
-           SupportUrl = "https://help.yourcompany.com",
-           SupportPhoneNumber = "+1-555-123-4567",
-           SupportEmail = "support@yourcompany.com",
-           PrivacyPolicyUrl = "https://yourcompany.com/privacy",
-           TermsAndConditionsUrl = "https://yourcompany.com/terms"
+           ["version"] = "2.1",
+           ["approval_status"] = "approved"
        }
    });
 

--- a/src/AccessGrid.csproj
+++ b/src/AccessGrid.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <PackageId>accessgrid</PackageId>
-    <Version>1.2.2</Version>
+    <Version>1.3.0</Version>
     <Authors>AccessGrid</Authors>
     <Company>AccessGrid</Company>
     <Description>Official C# SDK for the AccessGrid API</Description>

--- a/src/AccessGrid/AccessGridClient.cs
+++ b/src/AccessGrid/AccessGridClient.cs
@@ -19,7 +19,7 @@ namespace AccessGrid
         private readonly string _accountId;
         private readonly string _secretKey;
         private readonly JsonSerializerOptions _jsonOptions;
-        private const string Version = "1.0.0";
+        private const string Version = "1.3.0";
 
         /// <summary>
         /// Service for managing access cards

--- a/src/AccessGrid/Models.cs
+++ b/src/AccessGrid/Models.cs
@@ -396,16 +396,58 @@ namespace AccessGrid
         public int? IPhoneCount { get; set; }
 
         /// <summary>
-        /// Object representing card template design
+        /// Must be a 6 character hexadecimal value for the background color, i.e. #FFFFFF
         /// </summary>
-        [JsonPropertyName("design")]
-        public TemplateDesign Design { get; set; }
+        [JsonPropertyName("background_color")]
+        public string BackgroundColor { get; set; }
 
         /// <summary>
-        /// Information for users that shows up on the back of the NFC key
+        /// Must be a 6 character hexadecimal value for the label color, i.e. #000000
         /// </summary>
-        [JsonPropertyName("support_info")]
-        public SupportInfo SupportInfo { get; set; }
+        [JsonPropertyName("label_color")]
+        public string LabelColor { get; set; }
+
+        /// <summary>
+        /// Must be a 6 character hexadecimal value for the secondary label color, i.e. #333333
+        /// </summary>
+        [JsonPropertyName("label_secondary_color")]
+        public string LabelSecondaryColor { get; set; }
+
+        /// <summary>
+        /// Shows on the back of the issued NFC key
+        /// </summary>
+        [JsonPropertyName("support_url")]
+        public string SupportUrl { get; set; }
+
+        /// <summary>
+        /// Shows on the back of the issued NFC key
+        /// </summary>
+        [JsonPropertyName("support_phone_number")]
+        public string SupportPhoneNumber { get; set; }
+
+        /// <summary>
+        /// Shows on the back of the issued NFC key
+        /// </summary>
+        [JsonPropertyName("support_email")]
+        public string SupportEmail { get; set; }
+
+        /// <summary>
+        /// Shows on the back of the issued NFC key
+        /// </summary>
+        [JsonPropertyName("privacy_policy_url")]
+        public string PrivacyPolicyUrl { get; set; }
+
+        /// <summary>
+        /// Shows on the back of the issued NFC key
+        /// </summary>
+        [JsonPropertyName("terms_and_conditions_url")]
+        public string TermsAndConditionsUrl { get; set; }
+
+        /// <summary>
+        /// Optional metadata key-value pairs
+        /// </summary>
+        [JsonPropertyName("metadata")]
+        public Dictionary<string, object> Metadata { get; set; }
     }
 
     public class UpdateTemplateRequest


### PR DESCRIPTION
Replace nested Design/SupportInfo objects with flat fields (background_color, label_color, support_url, etc.) matching the API's template_params. Add Metadata field. Update README example and bump version to 1.3.0.