### PR TITLE
Fix use_case docstring/example to match API

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ public async Task CreateTemplateAsync()
    {
        Name = "Employee Access Pass",
        Platform = "apple",
-       UseCase = "employee_badge",
+       UseCase = "corporate_id",
        Protocol = "desfire",
        AllowOnMultipleDevices = true,
        WatchCount = 2,

--- a/src/AccessGrid/Models.cs
+++ b/src/AccessGrid/Models.cs
@@ -408,7 +408,7 @@ namespace AccessGrid
         public Platform Platform { get; set; }
 
         /// <summary>
-        /// Must be `employee_badge`
+        /// Must be one of `corporate_id`, `student_id`, `multi_family`, or `hotel`
         /// </summary>
         [JsonPropertyName("use_case")]
         public string UseCase { get; set; }


### PR DESCRIPTION
SDK doc and README claimed `use_case` must be `employee_badge`, but the Rails API only accepts `corporate_id`, `student_id`, `multi_family`, or `hotel`. The wrong value causes template creation to fail with an "invalid use_case" error.