### PR TITLE
Parse LedgerItem.amount from JSON string

### DIFF
--- a/AccessGridTest/ConsoleServiceTests.cs
+++ b/AccessGridTest/ConsoleServiceTests.cs
@@ -566,6 +566,31 @@ public class ConsoleServiceTests
     }
 
     [Test]
+    public async Task GetLedgerItemsAsync_ParsesAmountFromJsonString()
+    {
+        // Rails serializes BigDecimal as a JSON string, not a number.
+        var json = """
+        {
+            "ledger_items": [
+                {
+                    "created_at": "2025-06-15T14:30:00Z",
+                    "amount": "-1.50",
+                    "id": "li_abc123",
+                    "kind": "access_pass_debit"
+                }
+            ],
+            "pagination": { "current_page": 1, "per_page": 50, "total_pages": 1, "total_count": 1 }
+        }
+        """;
+        StubHttpResponse(json);
+
+        var result = await _client.Console.GetLedgerItemsAsync();
+
+        Assert.That(result.LedgerItems, Has.Count.EqualTo(1));
+        Assert.That(result.LedgerItems[0].Amount, Is.EqualTo(-1.50m));
+    }
+
+    [Test]
     public async Task GetLedgerItemsAsync_PassesDateFilters()
     {
         var json = """

--- a/src/AccessGrid/Models.cs
+++ b/src/AccessGrid/Models.cs
@@ -778,6 +778,7 @@ namespace AccessGrid
         public DateTime? CreatedAt { get; set; }
 
         [JsonPropertyName("amount")]
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
         public decimal Amount { get; set; }
 
         [JsonPropertyName("id")]


### PR DESCRIPTION
Rails serializes BigDecimal as a JSON string (e.g. `"-49.0"`) to preserve precision, but the SDK typed `LedgerItem.Amount` as a raw decimal, causing `GetLedgerItemsAsync` to throw JsonException on real API responses. Adds `JsonNumberHandling.AllowReadingFromString` so the property reads both number and string forms, plus a test covering the string case.