### PR TITLE
Document landing page kind enum values

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ public async Task CreateLandingPageAsync()
     var landingPage = await client.Console.CreateLandingPageAsync(new CreateLandingPageRequest
     {
         Name = "Miami Office Access Pass",
-        Kind = "universal",
+        Kind = "universal", // "universal" or "personalized"
         AdditionalText = "Welcome to the Miami Office",
         BgColor = "#f1f5f9",
         AllowImmediateDownload = true

--- a/src/AccessGrid/Models.cs
+++ b/src/AccessGrid/Models.cs
@@ -1134,6 +1134,9 @@ namespace AccessGrid
         [JsonPropertyName("name")]
         public string Name { get; set; }
 
+        /// <summary>
+        /// Must be `universal` or `personalized`
+        /// </summary>
         [JsonPropertyName("kind")]
         public string Kind { get; set; }
 


### PR DESCRIPTION
Adds a docstring to `CreateLandingPageRequest.Kind` and an inline comment in the README example clarifying that the field accepts `universal` or `personalized`.