### PR TITLE
Allow null for credential profile numeric fields

### DIFF
--- a/AccessGridTest/ConsoleServiceTests.cs
+++ b/AccessGridTest/ConsoleServiceTests.cs
@@ -1161,6 +1161,33 @@ public class ConsoleServiceTests
     }
 
     [Test]
+    public async Task CredentialProfilesListAsync_HandlesNullNumericFields()
+    {
+        // The API can return null for keys_diversified and file_size; the SDK
+        // previously typed these as non-nullable bool/int and crashed.
+        var json = """
+        [
+            {
+                "id": "cp_1",
+                "name": "Profile",
+                "keys": [
+                    { "ex_id": "key_1", "label": "Master Key", "keys_diversified": null, "source_key_index": null }
+                ],
+                "files": [
+                    { "ex_id": "file_1", "file_type": "Standard", "file_size": null }
+                ]
+            }
+        ]
+        """;
+        StubHttpResponse(json);
+
+        var result = await _client.Console.CredentialProfiles.ListAsync();
+
+        Assert.That(result[0].Keys[0].KeysDiversified, Is.Null);
+        Assert.That(result[0].Files[0].FileSize, Is.Null);
+    }
+
+    [Test]
     public async Task CredentialProfilesListAsync_ShouldHandleEmptyList()
     {
         StubHttpResponse("[]");

--- a/src/AccessGrid/Models.cs
+++ b/src/AccessGrid/Models.cs
@@ -1195,7 +1195,7 @@ namespace AccessGrid
         public string Label { get; set; }
 
         [JsonPropertyName("keys_diversified")]
-        public bool KeysDiversified { get; set; }
+        public bool? KeysDiversified { get; set; }
 
         [JsonPropertyName("source_key_index")]
         public int? SourceKeyIndex { get; set; }
@@ -1213,7 +1213,7 @@ namespace AccessGrid
         public string FileType { get; set; }
 
         [JsonPropertyName("file_size")]
-        public int FileSize { get; set; }
+        public int? FileSize { get; set; }
 
         [JsonPropertyName("communication_settings")]
         public string CommunicationSettings { get; set; }


### PR DESCRIPTION
The API can return null for `keys_diversified` and `file_size`, but the SDK typed them as non-nullable `bool` and `int`, causing `CredentialProfilesService.ListAsync` to throw JsonException on real responses. Makes both fields nullable and adds a regression test.